### PR TITLE
fix mousetrap backtick catching

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -205,6 +205,12 @@
         }
 
         if (_KEYCODE_MAP[e.which]) {
+            // HACK: on foreign language keyboards the keycode 192 is used for a ton of other keys
+            // for those cases, it is relatively safe to override the mapping and just use the newer
+            // event key property
+            if (e.which === 192) {
+                return e.key
+            }
             return _KEYCODE_MAP[e.which];
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superhuman-mousetrap",
-  "version": "1.5.3-sh.1",
+  "version": "1.5.3-sh.2",
   "description": "Simple library for handling keyboard shortcuts",
   "main": "mousetrap.js",
   "directories": {


### PR DESCRIPTION
Mousetrap uses the old keyCode property which appears to use the same code for different keys on different keyboards

https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode